### PR TITLE
Add specification and docstring for data_version_diff function

### DIFF
--- a/src/csvplus/data_version_diff.py
+++ b/src/csvplus/data_version_diff.py
@@ -1,0 +1,76 @@
+def data_version_diff(df_old, df_new):
+    """
+    Compare two versions of a pandas DataFrame and summarize their differences.
+
+    This function is intended to support data auditing, reproducibility, and
+    exploratory analysis by identifying structural and statistical differences
+    between two versions of a dataset. Rather than performing a cell-by-cell
+    comparison, the function provides a high-level summary of how the datasets
+    differ.
+
+    The comparison includes:
+    - Columns that were added or removed
+    - Changes in row counts
+    - Changes in missing values by column
+    - Changes in summary statistics for numeric columns
+    - Changes in data types
+
+    Parameters
+    ----------
+    df_old : pandas.DataFrame
+        The original or earlier version of the dataset.
+
+    df_new : pandas.DataFrame
+        The updated or later version of the dataset.
+
+    Returns
+    -------
+    dict
+        A dictionary summarizing the differences between the two DataFrames with
+        the following keys:
+
+        - 'columns_added' : list of str
+            Column names present in `df_new` but not in `df_old`.
+
+        - 'columns_removed' : list of str
+            Column names present in `df_old` but not in `df_new`.
+
+        - 'row_count_change' : dict
+            A dictionary with keys:
+                - 'old' : int
+                    Number of rows in `df_old`.
+                - 'new' : int
+                    Number of rows in `df_new`.
+                - 'difference' : int
+                    Difference in row counts (`new - old`).
+
+        - 'missing_value_changes' : pandas.DataFrame
+            A DataFrame summarizing changes in missing value counts for columns
+            present in both datasets.
+
+        - 'numeric_summary_changes' : pandas.DataFrame
+            A DataFrame summarizing changes in summary statistics (e.g., mean,
+            standard deviation, minimum, maximum) for numeric columns present
+            in both datasets.
+
+        - 'dtype_changes' : pandas.DataFrame
+            A DataFrame listing columns whose data types differ between
+            `df_old` and `df_new`.
+
+    Notes
+    -----
+    - This function assumes both inputs are pandas DataFrames.
+    - Rows are compared by position only; no key-based row matching is performed.
+    - The function is intended for small to medium-sized datasets and exploratory
+      analysis rather than large-scale production pipelines.
+
+    Examples
+    --------
+    >>> diff = data_version_diff(df_v1, df_v2)
+    >>> diff["columns_added"]
+    ['new_feature']
+
+    >>> diff["row_count_change"]["difference"]
+    150
+    """
+    pass


### PR DESCRIPTION
This pull request adds the function specification and complete docstring for data_version_diff(). The function is intended to compare two versions of a pandas DataFrame and summarize their structural and statistical differences. This PR is associated with Issue #9.
