### PR TITLE
corrected test_generate_report to adhere to flake8

### DIFF
--- a/tests/unit/test_generate_report.py
+++ b/tests/unit/test_generate_report.py
@@ -10,6 +10,7 @@ Claude.ai was used to perform the following tasks:
 
 import pytest
 import pandas as pd
+import numpy as np
 from csvplus.generate_report import summary_report
 
 
@@ -56,7 +57,7 @@ class TestInputValidation:
         returns all unique values without error."""
         df = pd.DataFrame({'x': ['a', 'b', 'c', 'c']})
         _, cat_stats = summary_report(df, top_n=100)
-        
+
         top_vals = cat_stats.loc['x', 'top_values']
         assert len(top_vals) == 3
         assert set(top_vals.keys()) == {'a', 'b', 'c'}
@@ -155,7 +156,7 @@ class TestCategoricalColumns:
         assert cat_stats.loc['city', 'n_missing'] == 0
         assert cat_stats.loc['city', 'n_unique'] == 3
         assert cat_stats.loc['city', 'unique_prop'] == 0.6
-        assert cat_stats.loc['city', 'is_constant'] == False
+        assert cat_stats.loc['city', 'is_constant'] == np.False_
 
     def test_categorical_with_missing(self):
         """Test creation of categorical report where
@@ -173,7 +174,7 @@ class TestCategoricalColumns:
         df = pd.DataFrame({'const': ['same', 'same', 'same']})
         _, cat_stats = summary_report(df)
 
-        assert cat_stats.loc['const', 'is_constant'] == True
+        assert cat_stats.loc['const', 'is_constant'] is np.True_
         assert cat_stats.loc['const', 'n_unique'] == 1
 
     def test_top_values_default_n(self):
@@ -361,5 +362,5 @@ class TestEdgeCases:
         df = pd.DataFrame({'dup': ['a'] * 100})
         _, cat_stats = summary_report(df)
 
-        assert cat_stats.loc['dup', 'is_constant'] == True
+        assert cat_stats.loc['dup', 'is_constant'] == np.True_
         assert cat_stats.loc['dup', 'top_1_prop'] == 1.0


### PR DESCRIPTION
- [x] fix #85
- [x] description of feature/fix
- [ ] tests added/passed
- [ ] add an entry to the [changelog](../CHANGELOG.md)

Removed trailing whitespace
edited x == False to x == np.False_
imported numpy module
