### PR TITLE
Fix action version and add skip-existing option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: hatch build
 
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v-1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
Fix deploy.yml action version and add skip-existing option to allow not publishing to pypi if the version is already published.